### PR TITLE
Vecto.rs only support PostgreSQL 14+

### DIFF
--- a/cicd/shared.sh
+++ b/cicd/shared.sh
@@ -269,8 +269,8 @@ check_others() {
     fi
 
     record_ext_version pgvecto.rs "$pg" ""
-    # TODO: pgvecto.rs hasn't released a pg17 compatible version yet, check https://github.com/tensorchord/pgvecto.rs/releases
-    if [[ -n "$PGVECTO_RS" && "$pg" -gt 13 && "$pg" -lt 17 ]]; then
+    # Vecto.rs only support PostgreSQL 14+
+    if [[ -n "$PGVECTO_RS" && "$pg" -ge 14 ]]; then
         if [ -s "$lib/vectors.so" ]; then
             record_ext_version pgvecto.rs "$pg" "$PGVECTO_RS"
         else


### PR DESCRIPTION
Vecto.rs only support PostgreSQL 14+. This includes pg17 support.